### PR TITLE
Fix appdata.xml which was failing to validate

### DIFF
--- a/com.endlessnetwork.MidnightmareTeddy.appdata.xml
+++ b/com.endlessnetwork.MidnightmareTeddy.appdata.xml
@@ -6,6 +6,7 @@
   <summary>Shoot and survive</summary>
   <project_license>LicenseRef-proprietary</project_license>
   <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">http://thethirdterminal.com</url>
   <categories>
     <category>LearnToCode</category>
     <category>Game</category>

--- a/com.endlessnetwork.MidnightmareTeddy.appdata.xml
+++ b/com.endlessnetwork.MidnightmareTeddy.appdata.xml
@@ -6,7 +6,7 @@
   <summary>Shoot and survive</summary>
   <project_license>LicenseRef-proprietary</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <url type="homepage">http://thethirdterminal.com</url>
+  <url type="homepage">https://terminaltwo.com/</url>
   <categories>
     <category>LearnToCode</category>
     <category>Game</category>


### PR DESCRIPTION
The following validator was failing...

    flatpak run org.freedesktop.appstream-glib validate com.endlessnetwork.MidnightmareTeddy.appdata.xml

With this output:

    com.endlessnetwork.MidnightmareTeddy.appdata.xml: FAILED:
    • tag-missing           : <url> is not present
